### PR TITLE
redesign about page with clean two-column layout

### DIFF
--- a/src/app/(external)/about-us/about.css
+++ b/src/app/(external)/about-us/about.css
@@ -1,0 +1,245 @@
+/* ========== Page Wrapper ========== */
+.about-page {
+  background: #fff;
+}
+
+/* ========== SECTION 1 — HERO ========== */
+.about-hero {
+  display: flex;
+  align-items: center;
+  height: 100vh;
+  padding: 0 0 60px 0;
+}
+
+.about-hero-image {
+  position: relative;
+  width: 47%;
+  flex-shrink: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.about-hero-content {
+  flex: 1;
+  padding: 48px 64px;
+}
+
+.about-hero-heading {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  font-weight: 400;
+  line-height: 1.1;
+  color: #000;
+  margin: 0 0 24px;
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.about-hero-sub {
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  color: #111;
+  line-height: 1.65;
+  margin: 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  max-width: 480px;
+}
+
+/* ========== SECTION 2 — SPERO NAME ========== */
+.about-spero {
+  display: flex;
+  align-items: stretch;
+  min-height: 60vh;
+}
+
+.about-spero-text {
+  width: 47%;
+  flex-shrink: 0;
+  padding: 80px 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  text-align: right;
+}
+
+.about-spero-heading {
+  font-size: clamp(1.5rem, 2.5vw, 2.25rem);
+  font-weight: 400;
+  color: #000;
+  margin: 0 0 28px;
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.about-spero-body {
+  font-size: clamp(0.875rem, 1.1vw, 1rem);
+  color: #111;
+  line-height: 1.75;
+  margin: 0;
+  max-width: 520px;
+  font-family: Georgia, 'Times New Roman', serif;
+  text-align: right;
+}
+
+.about-spero-image {
+  position: relative;
+  flex: 1;
+  min-height: 400px;
+  overflow: hidden;
+}
+
+/* ========== SECTION 3 — MISSION ========== */
+.about-mission {
+  display: flex;
+  align-items: stretch;
+  min-height: 60vh;
+  margin-top: 80px;
+}
+
+.about-mission-image {
+  position: relative;
+  width: 47%;
+  flex-shrink: 0;
+  min-height: 420px;
+  overflow: hidden;
+}
+
+.about-mission-content {
+  flex: 1;
+  padding: 72px 64px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.about-mission-heading {
+  font-size: clamp(1.5rem, 2.5vw, 2.25rem);
+  font-weight: 400;
+  color: #000;
+  margin: 0 0 24px;
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.about-mission-body {
+  font-size: clamp(0.875rem, 1.1vw, 1rem);
+  color: #111;
+  line-height: 1.7;
+  margin: 0 0 20px;
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.about-mission-body:last-child {
+  margin-bottom: 0;
+}
+
+/* ========== SECTION 4 — PASTOR GPT ========== */
+.about-pastorgpt {
+  width: 100%;
+  background: #f8fafc;
+  padding: 96px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 24px;
+  margin-top: 80px;
+}
+
+.about-pastorgpt-heading {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.2;
+  max-width: 640px;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.about-pastorgpt-sub {
+  font-size: 1.1rem;
+  color: #334155;
+  max-width: 520px;
+  line-height: 1.6;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.about-pastorgpt-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 14px 32px;
+  background: #000;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.about-pastorgpt-btn:hover {
+  background: #1a1a1a;
+  transform: translateY(-2px);
+}
+
+.about-pastorgpt-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* ========== Responsive ========== */
+@media (max-width: 768px) {
+  .about-hero {
+    flex-direction: column;
+    min-height: auto;
+  }
+
+  .about-hero {
+    height: auto;
+    min-height: 100vh;
+    padding: 40px 24px;
+    flex-direction: column;
+  }
+
+  .about-hero-image {
+    width: 100%;
+    height: 56vw;
+    min-height: 240px;
+  }
+
+  .about-hero-content {
+    padding: 36px 24px;
+  }
+
+  .about-spero {
+    flex-direction: column;
+  }
+
+  .about-spero-text {
+    width: 100%;
+    padding: 48px 24px;
+    border-right: none;
+  }
+
+  .about-spero-image {
+    min-height: 300px;
+  }
+
+  .about-mission {
+    flex-direction: column;
+    margin-top: 40px;
+  }
+
+  .about-mission-image {
+    width: 100%;
+    min-height: 300px;
+  }
+
+  .about-mission-content {
+    padding: 48px 24px;
+  }
+
+  .about-pastorgpt {
+    margin-top: 40px;
+  }
+}

--- a/src/app/(external)/about-us/about.tsx
+++ b/src/app/(external)/about-us/about.tsx
@@ -1,213 +1,109 @@
 'use client';
 
-import {
-  Box,
-  Container,
-  Heading,
-  Image,
-  VStack,
-  Text,
-  SimpleGrid,
-  Flex,
-  Center,
-  Button,
-  HStack,
-} from '@chakra-ui/react';
-import { Inter } from 'next/font/google';
-import { ExternalLinkIcon } from '@chakra-ui/icons';
-import { SPERO_BACKGROUND_RECESSED } from '@/lib/colors';
-import NextImage from 'next/image';
-
-const inter = Inter({ subsets: ['latin'] });
+import Image from 'next/image';
+import './about.css';
 
 export default function AboutPage() {
   return (
-    <Box bg="white">
-      <Box mb={16}>
-        <Box
-          width="100%"
-          aspectRatio={16 / 5.4}
-          overflow="hidden"
-          position="relative"
-        >
-          <NextImage
+    <div className="about-page">
+
+      {/* SECTION 1 — HERO */}
+      <section className="about-hero">
+        <div className="about-hero-image">
+          <Image
             src="/images/team/team.webp"
             alt="Spero Team"
             fill
             priority
-            sizes="100vw"
-            quality={100}
-            style={{
-              objectFit: "cover",
-              objectPosition: "top"
-            }}
+            sizes="(max-width: 768px) 100vw, 47vw"
+            style={{ objectFit: 'cover', objectPosition: 'center center' }}
           />
-        </Box>
-        <Box bg={SPERO_BACKGROUND_RECESSED} py={12}>
-          <Container maxW="container.lg">
-            <VStack spacing={6} textAlign="center" className={inter.className}>
-              <Heading
-                as="h1"
-                fontSize={{ base: '4xl', md: '6xl' }}
-                fontWeight="bold"
-                color="black"
-                lineHeight="1.1"
-              >
-                We are Spero
-              </Heading>
-              <VStack spacing={2}>
-                <Text
-                  fontSize={{ base: 'lg', md: 'xl' }}
-                  color="black"
-                  fontStyle="italic"
-                  fontWeight="normal"
-                >
-                  a team of college students with a heart to share the gospel with biblically empowered apparel.
-                </Text>
-              </VStack>
-            </VStack>
-          </Container>
-        </Box>
-      </Box>
+        </div>
+        <div className="about-hero-content">
+          <h1 className="about-hero-heading">We are Spero.</h1>
+          <p className="about-hero-sub">
+            a team of college students with a heart to share the gospel with
+            biblically empowered apparel.
+          </p>
+        </div>
+      </section>
 
-      {/* Mission Section */}
-      <Box bg="white" py={16}>
-        <Container maxW="container.lg">
-          <SimpleGrid columns={{ base: 1, md: 2 }} spacing={12}>
-            {/* Left Image */}
-            <Center>
-              <Image
-                src="/images/home/confidence-1.jpg"
-                alt="Confidence Design"
-                borderRadius="md"
-                objectFit="contain"
-                maxHeight="400px"
-                maxWidth="100%"
-              />
-            </Center>
+      {/* SECTION 2 — SPERO NAME */}
+      <section className="about-spero">
+        <div className="about-spero-text">
+          <h2 className="about-spero-heading">&ldquo;Spero&rdquo;</h2>
+          <p className="about-spero-body">
+            In Latin, the word &ldquo;spero&rdquo; means &ldquo;to hope.&rdquo;
+            Our vision is deeply rooted in Matthew 10:29&ndash;31, where
+            something as insignificant as a sparrow, worth only a penny, is
+            valued much greater and cared for by God. This reminds us that we
+            hope in the living hope, who bridged the gap that once separated
+            us from Him. We also look up to see sparrows, the same way we
+            strive to look up to Christ daily as we navigate through our lives.
+          </p>
+        </div>
+        <div className="about-spero-image">
+          <Image
+            src="/images/designs/hope-1.jpg"
+            alt="Spero hope design"
+            fill
+            sizes="(max-width: 768px) 100vw, 53vw"
+            style={{ objectFit: 'cover' }}
+          />
+        </div>
+      </section>
 
-            {/* Right Text */}
-            <Flex height="400px" alignItems="center">
-              <VStack align="start" spacing={6} className={inter.className}>
-                <Text fontSize="lg" color="black" lineHeight="1.6">
-                  Spero is a{' '}
-                  <Text as="span" fontWeight="bold" color="black">
-                    gospel-centered clothing brand
-                  </Text>{' '}
-                  dedicated to creating scripture-based streetwear that serves as
-                  both a statement of faith and a tool for evangelism. Our mission
-                  is to{' '}
-                  <Text as="span" fontWeight="bold" color="black">
-                    spread the Word of God
-                  </Text>{' '}
-                  by incorporating Bible verses into every design and producing
-                  intentional designs that spark hope through everyday wear, spark
-                  conversations with both unbelievers and believers, and
-                  encouraging wearers to live boldly in their faith. As Romans
-                  1:16 states, &ldquo;
-                  <Text as="span" fontWeight="bold" color="black">
-                    It is the power of God that brings salvation.
-                  </Text>
-                  &rdquo; We believe that fashion can be a vessel for faith,
-                  allowing those who wear our clothing to carry the Gospel
-                  wherever they go. 30% of all profits are donated to
-                  Gospel-centered organizations and missionaries that focus on
-                  planting churches in third world countries. Our focus this year
-                  is to support church planting in Haiti!
-                </Text>
-              </VStack>
-            </Flex>
-          </SimpleGrid>
-        </Container>
-      </Box>
+      {/* SECTION 3 — MISSION */}
+      <section className="about-mission">
+        <div className="about-mission-image">
+          <Image
+            src="/images/designs/flowers-1.jpg"
+            alt="God Clothes the Flowers of the Field"
+            fill
+            sizes="(max-width: 768px) 100vw, 47vw"
+            style={{ objectFit: 'cover', objectPosition: 'center center' }}
+          />
+        </div>
+        <div className="about-mission-content">
+          <h2 className="about-mission-heading">Our Mission</h2>
+          <p className="about-mission-body">
+            Spero is a gospel-centered clothing brand dedicated to creating
+            scripture-based streetwear that serves as both a statement of faith
+            and a tool for evangelism.
+          </p>
+          <p className="about-mission-body">
+            Our mission is to spread the Word of God by incorporating Bible
+            verses into every design and producing intentional designs that
+            spark hope through everyday wear, spark conversations with both
+            unbelievers and believers, and encouraging wearers to live boldly
+            for Christ.
+          </p>
+        </div>
+      </section>
 
-      {/* Vision Section */}
-      <Box bg="white" py={16}>
-        <Container maxW="container.lg">
-          <SimpleGrid columns={{ base: 1, md: 2 }} spacing={12}>
-            {/* Left Text */}
-            <Flex height="400px" alignItems="center">
-              <VStack align="start" spacing={6} className={inter.className}>
-                <Text fontSize="lg" color="black" lineHeight="1.6">
-                  In Latin, the word &ldquo;spero&rdquo; means &ldquo;
-                  <Text as="span" fontWeight="bold" color="black">
-                    to hope
-                  </Text>
-                  .&rdquo; Our vision is deeply rooted in Matthew 10:29–31, where
-                  something as insignificant as a sparrow, worth only a penny, is
-                  valued much greater and cared for by God. This reminds us that
-                  we hope in the living hope, who bridged the gap that once
-                  separated us from Him. We also look up to see sparrows, the
-                  same way we strive to look up to Christ daily as we navigate
-                  through our lives.
-                </Text>
-              </VStack>
-            </Flex>
+      {/* SECTION 4 — PASTOR GPT */}
+      <section className="about-pastorgpt">
+        <h2 className="about-pastorgpt-heading">
+          Curious about learning more about Christianity?
+        </h2>
+        <p className="about-pastorgpt-sub">
+          Talk to PastorGPT and ask all your questions!
+        </p>
+        <a
+          href="https://chatgpt.com/g/g-A1ojXxmox-pastor-gpt"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="about-pastorgpt-btn"
+        >
+          Chat with PastorGPT
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <polyline points="15 3 21 3 21 9" />
+            <line x1="10" y1="14" x2="21" y2="3" />
+          </svg>
+        </a>
+      </section>
 
-            {/* Right Image */}
-            <Center>
-              <Image
-                src="/images/home/flowers-1.jpg"
-                alt="Flowers Design"
-                borderRadius="md"
-                objectFit="contain"
-                maxHeight="400px"
-                maxWidth="100%"
-              />
-            </Center>
-          </SimpleGrid>
-        </Container>
-      </Box>
-
-      {/* PastorGPT Section */}
-      <Box bg={SPERO_BACKGROUND_RECESSED} py={16}>
-        <Container maxW="container.lg">
-          <VStack spacing={8} textAlign="center" className={inter.className}>
-            <Heading
-              as="h2"
-              fontSize={{ base: '3xl', md: '4xl' }}
-              fontWeight="bold"
-              color="black"
-              lineHeight="1.2"
-            >
-              Curious about learning more about Christianity?
-            </Heading>
-            <Text
-              fontSize={{ base: 'lg', md: 'xl' }}
-              color="black"
-              maxW="600px"
-              lineHeight="1.6"
-            >
-              Talk to PastorGPT and ask all your questions!
-            </Text>
-            <Button
-              as="a"
-              href="https://chatgpt.com/g/g-A1ojXxmox-pastor-gpt"
-              target="_blank"
-              rel="noopener noreferrer"
-              size="lg"
-              bg="black"
-              color="white"
-              _hover={{
-                bg: "gray.800",
-                transform: "translateY(-2px)",
-                boxShadow: "lg",
-              }}
-              transition="all 0.2s"
-              px={8}
-              py={6}
-              fontSize="lg"
-              fontWeight="medium"
-              borderRadius="md"
-            >
-              <HStack spacing={2}>
-                <Text>Chat with PastorGPT</Text>
-                <ExternalLinkIcon boxSize={4} />
-              </HStack>
-            </Button>
-          </VStack>
-        </Container>
-      </Box>
-    </Box>
+    </div>
   );
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -64,6 +64,7 @@ export default function NavBar({ links }: Readonly<{ links: LinkInfo[] }>) {
   // Check if on home page or designs page
   const isHomePage = pathname === '/';
   const isDesignsPage = pathname === '/designs';
+  const isAboutPage = pathname === '/about-us';
 
   // Dynamically set styling based on scroll/page
   const isTransparent = (isAtTop && isHomePage) || (isDesignsPage && scrollingDown);


### PR DESCRIPTION
## Closes
<!-- Link the issue this PR closes (e.g., Closes #123) -->
about page redesign

## Description
<!-- Briefly describe your changes -->
- Replace dark editorial layout with minimal white design
- Hero: full-viewport team photo flush left with "We are Spero." text right
- Add "Spero" name section (right-aligned text + hope design image)
- Add Our Mission section (flowers shirt image + body text)
- Consistent Georgia serif typography throughout
- Remove transparent navbar behavior on about page so header shows solid
- Add navbar spacer so content sits below header
## Screenshots (Before and After)
<!-- Add screenshots or GIFs to show visual changes -->

| Before | After |
| --- | --- |
| 
<img width="1792" height="963" alt="image" src="https://github.com/user-attachments/assets/8a4a5f51-7ac2-4da3-8bae-8958842c6314" />
|
<img width="1792" height="1030" alt="image" src="https://github.com/user-attachments/assets/8130cb1c-19ec-48c5-9319-8c537ccf52bd" />
|

## Checklist
- [x] I have reviewed my code
- [x] No compilation errors
- [x] Works locally
