### PR TITLE
Mark God Is Love sold out

### DIFF
--- a/src/app/(external)/shop/ShopGodIsLove.tsx
+++ b/src/app/(external)/shop/ShopGodIsLove.tsx
@@ -32,7 +32,7 @@ export default function ShopGodIsLove() {
     images: imageList,
     sizes,
     stripeId: 'god-is-love',
-    isSoldOut: false,
+    isSoldOut: true,
   };
 
   return <Product {...props} />;


### PR DESCRIPTION
## Summary

Marks the active God Is Love shop item as sold out so the checkout UI disables purchasing for this no-longer-sold product.

## Why

Production Discord logs showed checkout attempts calling `reserveInventory(god-is-love-s)`, `reserveInventory(god-is-love-m)`, and `reserveInventory(god-is-love-l)`. Those Firestore product documents do not exist, so reservation fails before Stripe checkout is created. Since God Is Love is no longer being sold, disabling checkout for that product is the intended behavior.

## Impact

Customers can still view the product page, but the checkout button now shows `Sold Out` and cannot call the missing inventory records.

## Validation

- `npm run build`